### PR TITLE
change API to null return instead of exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,19 @@ var bs58check = require('bs58check')
 var qs = require('qs')
 
 function decode (uri) {
-  var qregex = /bitcoin:\/?\/?([^?]+)(\?([^]+))?/.exec(uri)
-  if (!qregex) return
+  if (uri.indexOf('bitcoin:') !== 0) return
 
-  // throws if invalid
-  var address = qregex[1]
+  var split = uri.split('?')
+  if (split.length > 2) return
+
+  // truncate bitcoin: (or non-compliant bitcoin://)
+  var address = split[0]
+  if (address.indexOf('//') === 8) address = address.slice(10)
+  else address = address.slice(8)
+
   if (!bs58check.decodeRaw(address)) return
 
-  var query = qregex[3]
+  var query = split[1]
   var options = qs.parse(query)
   if (options.amount !== undefined) {
     var amount = parseFloat(options.amount)

--- a/index.js
+++ b/index.js
@@ -6,41 +6,40 @@ var qs = require('qs')
 
 function decode (uri) {
   var qregex = /bitcoin:\/?\/?([^?]+)(\?([^]+))?/.exec(uri)
-  if (!qregex) throw new Error('Invalid BIP21 URI: ' + uri)
-
-  var address = qregex[1]
+  if (!qregex) return
 
   // throws if invalid
-  bs58check.decode(address)
+  var address = qregex[1]
+  if (!bs58check.decodeRaw(address)) return
 
   var query = qregex[3]
-  var parsed = qs.parse(query)
+  var options = qs.parse(query)
+  if (options.amount !== undefined) {
+    var amount = parseFloat(options.amount)
+    if (typeof amount !== 'number') return
+    if (!isFinite(amount)) return
+    if (amount < 0) return
 
-  parsed.address = address
-
-  if (parsed.amount) {
-    parsed.amount = parseFloat(parsed.amount)
-
-    if (!isFinite(parsed.amount)) throw new Error('Invalid amount')
-    if (parsed.amount < 0) throw new Error('Invalid amount')
+    // BTC -> satoshis
+    options.amount = amount * 1e8
   }
 
-  return parsed
+  return {
+    address: address,
+    options: options
+  }
 }
 
 function encode (address, options) {
-  // throws if invalid
-  bs58check.decode(address)
+  var _options = {}
+  for (var k in options) _options[k] = options[k]
 
-  options = options || {}
-
-  if (options.amount) {
-    if (!isFinite(options.amount)) throw new TypeError('Invalid amount')
-    if (options.amount < 0) throw new TypeError('Invalid amount')
+  if (_options.amount !== undefined) {
+    // satoshis -> BTC
+    _options.amount /= 1e8
   }
 
-  var query = qs.stringify(options)
-
+  var query = qs.stringify(_options)
   return 'bitcoin:' + address + (query ? '?' : '') + query
 }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "bs58check": "^1.0.3",
+    "bs58check": "^1.1.1",
     "qs": "^6.0.2"
   },
   "devDependencies": {

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -2,17 +2,20 @@
   "valid": [
     {
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-      "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH"
+      "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
+      "options": {}
     },
     {
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
       "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?",
-      "compliant": false
+      "compliant": false,
+      "options": {}
     },
     {
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
       "uri": "bitcoin://1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-      "compliant": false
+      "compliant": false,
+      "options": {}
     },
     {
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
@@ -40,21 +43,14 @@
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
       "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=1",
       "options": {
-        "amount": 1
-      }
-    },
-    {
-      "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-      "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=1.00",
-      "options": {
-        "amount": "1.00"
+        "amount": 100000000
       }
     },
     {
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
       "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=20.3&label=Luke-Jr",
       "options": {
-        "amount": 20.3,
+        "amount": 2030000000,
         "label": "Luke-Jr"
       }
     },
@@ -62,7 +58,7 @@
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
       "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz",
       "options": {
-        "amount": 50,
+        "amount": 5000000000,
         "label": "Luke-Jr",
         "message": "Donation for project xyz"
       }
@@ -71,24 +67,24 @@
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
       "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=1&custom=foobar",
       "options": {
-        "amount": 1,
+        "amount": 100000000,
         "custom": "foobar"
       }
     },
     {
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-      "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.200000&r=https%3A%2F%2Fbitpay.com%2Fi%2Fxxxxxxxxxxxxxxxxxxxxxx",
+      "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.2&r=https%3A%2F%2Fbitpay.com%2Fi%2Fxxxxxxxxxxxxxxxxxxxxxx",
       "options": {
-        "amount": "0.200000",
+        "amount": 20000000,
         "r": "https://bitpay.com/i/xxxxxxxxxxxxxxxxxxxxxx"
       }
     },
     {
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-      "uri": "bitcoin://1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.200000&r=https%3A%2F%2Fbitpay.com%2Fi%2Fxxxxxxxxxxxxxxxxxxxxxx",
+      "uri": "bitcoin://1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.2&r=https%3A%2F%2Fbitpay.com%2Fi%2Fxxxxxxxxxxxxxxxxxxxxxx",
       "compliant": false,
       "options": {
-        "amount": "0.200000",
+        "amount": 20000000,
         "r": "https://bitpay.com/i/xxxxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -100,12 +96,10 @@
     },
     {
       "exception": "Invalid checksum",
-      "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26XXXX",
       "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26XXXX"
     },
     {
       "exception": "Invalid amount",
-      "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
       "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=-1",
       "options": {
         "amount": -1
@@ -113,14 +107,6 @@
     },
     {
       "exception": "Invalid amount",
-      "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-      "options": {
-        "amount": "-1"
-      }
-    },
-    {
-      "exception": "Invalid amount",
-      "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
       "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=-1.00",
       "options": {
         "amount": -1.00
@@ -128,7 +114,6 @@
     },
     {
       "exception": "Invalid amount",
-      "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
       "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=two",
       "options": {
         "amount": "two"

--- a/test/index.js
+++ b/test/index.js
@@ -3,44 +3,28 @@ var fixtures = require('./fixtures')
 var tape = require('tape')
 
 fixtures.valid.forEach(function (f) {
-  if (f.compliant === false) return
+  if (f.compliant !== false) {
+    tape('encodes ' + f.uri, function (t) {
+      var result = bip21.encode(f.address, f.options)
 
-  tape('encodes ' + f.uri, function (t) {
-    var result = bip21.encode(f.address, f.options)
-
-    t.plan(1)
-    t.equal(result, f.uri)
-  })
+      t.plan(1)
+      t.equal(result, f.uri)
+    })
+  }
 
   tape('decodes ' + f.uri + (f.compliant === false ? ' (non-compliant)' : ''), function (t) {
     var decode = bip21.decode(f.uri)
 
-    t.plan(f.options ? 4 : 1)
+    t.plan(2)
     t.equal(decode.address, f.address)
-
-    if (!f.options) return
-    t.equal(decode.amount, f.options.amount !== undefined ? parseFloat(f.options.amount) : undefined)
-    t.equal(decode.label, f.options.label)
-    t.equal(decode.message, f.options.message)
+    t.same(decode.options, f.options)
   })
 })
 
 fixtures.invalid.forEach(function (f) {
-  if (f.address) {
-    tape('throws ' + f.exception + ' for ' + f.uri, function (t) {
-      t.plan(1)
-      t.throws(function () {
-        bip21.encode(f.address, f.options)
-      }, new RegExp(f.exception))
-    })
-  }
+  tape('decode returns nothing for ' + f.uri + ' (' + f.exception + ')', function (t) {
+    if (bip21.decode(f.uri)) t.fail()
 
-  if (f.uri) {
-    tape('throws ' + f.exception + ' for ' + f.uri, function (t) {
-      t.plan(1)
-      t.throws(function () {
-        bip21.decode(f.uri)
-      }, new RegExp(f.exception))
-    })
-  }
+    t.end()
+  })
 })


### PR DESCRIPTION
I'm not 100% the regex isn't a DoS opportunity,  so I've removed it.
I've also moved to an exception-less API,  no return object is as good.

Lastly,  the final breaking change is that `amount` is automatically encoded to Satoshis.
This is done as `amount` *has* to be error-checked anyway,  and almost every library I know of uses Satoshi values anyway... so the its just 1 more step to always be doing.