### PR TITLE
Make address optional in decoding, for BIP72 urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 var qs = require('qs')
 
 function decode (uri) {
-  var qregex = /bitcoin:\/?\/?([^?]+)(\?([^]+))?/.exec(uri)
+  var qregex = /bitcoin:\/?\/?([^?]+)?(\?([^]+))?/.exec(uri)
   if (!qregex) throw new Error('Invalid BIP21 URI: ' + uri)
 
   var address = qregex[1]

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -91,6 +91,15 @@
         "amount": "0.200000",
         "r": "https://bitpay.com/i/xxxxxxxxxxxxxxxxxxxxxx"
       }
+    },
+    {
+      "address": "",
+      "uri": "bitcoin://?amount=0.200000&r=https%3A%2F%2Fbitpay.com%2Fi%2Fxxxxxxxxxxxxxxxxxxxxxx",
+      "compliant": false,
+      "options": {
+        "amount": "0.200000",
+        "r": "https://bitpay.com/i/xxxxxxxxxxxxxxxxxxxxxx"
+      }
     }
   ],
   "invalid": [


### PR DESCRIPTION
What do you think of supporting BIP72 in this library?

There are two parts to dealing with it 
 * backwards compatible setting the address/value, in addition to the `r` parameter.
 * non-compatible form lacking the address (details specified in the payment request)

I could maybe move it to a different function intending to support both if the changes would interact undesirably with existing usage.