### PR TITLE
Add support for alternative urn schemes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@
 
 var qs = require('qs')
 
-function decode (uri) {
-  var qregex = /bitcoin:\/?\/?([^?]+)(\?([^]+))?/.exec(uri)
+function decode (uri, urnScheme) {
+  var scheme = urnScheme || 'bitcoin'
+  var qregex = new RegExp(scheme + ':/?/?([^?]+)(\\?([^]+))?').exec(uri)
   if (!qregex) throw new Error('Invalid BIP21 URI: ' + uri)
 
   var address = qregex[1]
@@ -20,8 +21,9 @@ function decode (uri) {
   return { address: address, options: options }
 }
 
-function encode (address, options) {
+function encode (address, options, urnScheme) {
   options = options || {}
+  var scheme = urnScheme || 'bitcoin'
   var query = qs.stringify(options)
 
   if (options.amount) {
@@ -29,7 +31,7 @@ function encode (address, options) {
     if (options.amount < 0) throw new TypeError('Invalid amount')
   }
 
-  return 'bitcoin:' + address + (query ? '?' : '') + query
+  return scheme + ':' + address + (query ? '?' : '') + query
 }
 
 module.exports = {

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -91,6 +91,11 @@
         "amount": "0.200000",
         "r": "https://bitpay.com/i/xxxxxxxxxxxxxxxxxxxxxx"
       }
+    },
+    {
+      "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
+      "uri": "other:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
+      "urnScheme": "other"
     }
   ],
   "invalid": [
@@ -139,4 +144,3 @@
     }
   ]
 }
-

--- a/test/index.js
+++ b/test/index.js
@@ -6,14 +6,24 @@ fixtures.valid.forEach(function (f) {
   if (f.compliant === false) return
 
   tape('encodes ' + f.uri, function (t) {
-    var result = bip21.encode(f.address, f.options)
+    var result
+    if (f.urnScheme) {
+      result = bip21.encode(f.address, f.options, f.urnScheme)
+    } else {
+      result = bip21.encode(f.address, f.options)
+    }
 
     t.plan(1)
     t.equal(result, f.uri)
   })
 
   tape('decodes ' + f.uri + (f.compliant === false ? ' (non-compliant)' : ''), function (t) {
-    var decode = bip21.decode(f.uri)
+    var decode
+    if (f.urnScheme) {
+      decode = bip21.decode(f.uri, f.urnScheme)
+    } else {
+      decode = bip21.decode(f.uri)
+    }
 
     t.plan(f.options ? 4 : 1)
     t.equal(decode.address, f.address)


### PR DESCRIPTION
Hey,

thank you for this lib. I thought it makes sense to support other URN schemes too as it seems to be an easy modification.

This commit enables other urn schemes than `bitcoin` to be de-/encoded.

Please let me know what you think! 🙂