### PR TITLE
Fix Case bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .nyc_output
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+if: (type = push AND branch = master) OR type = pull_request
 sudo: false
 language: node_js
 node_js:

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var qs = require('qs')
 
 function decode (uri, urnScheme) {
   urnScheme = urnScheme || 'bitcoin'
-  if (uri.indexOf(urnScheme) !== 0 ||
+  var urnSchemeActual = uri.slice(0, urnScheme.length).toLowerCase()
+  if (urnSchemeActual !== urnScheme ||
     uri.charAt(urnScheme.length) !== ':'
   ) throw new Error('Invalid BIP21 URI: ' + uri)
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "bitcoin"
   ],
   "main": "./index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "coverage-report": "nyc report --reporter=lcov",
     "coverage": "nyc --check-coverage --branches 90 --functions 90 npm run unit",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "qs": "^6.3.0"
   },
   "devDependencies": {
-    "nyc": "^6.4.0",
+    "nyc": "^15.0.1",
     "standard": "*",
     "tape": "^4.9.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bip21",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A BIP21 compatible URL encoding utility library",
   "author": "Daniel Cousens",
   "license": "MIT",

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -38,14 +38,14 @@
     },
     {
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-      "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=1",
+      "uri": "bitCOIN:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=1",
       "options": {
         "amount": 1
       }
     },
     {
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-      "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=1.00",
+      "uri": "BITcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=1.00",
       "options": {
         "amount": "1.00"
       }
@@ -69,7 +69,7 @@
     },
     {
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-      "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=1&custom=foobar",
+      "uri": "BitCoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=1&custom=foobar",
       "options": {
         "amount": 1,
         "custom": "foobar"
@@ -77,7 +77,7 @@
     },
     {
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-      "uri": "bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.200000&r=https%3A%2F%2Fbitpay.com%2Fi%2Fxxxxxxxxxxxxxxxxxxxxxx",
+      "uri": "BITCOIN:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=0.200000&r=https%3A%2F%2Fbitpay.com%2Fi%2Fxxxxxxxxxxxxxxxxxxxxxx",
       "options": {
         "amount": "0.200000",
         "r": "https://bitpay.com/i/xxxxxxxxxxxxxxxxxxxxxx"

--- a/test/index.js
+++ b/test/index.js
@@ -14,7 +14,8 @@ fixtures.valid.forEach(function (f) {
     }
 
     t.plan(1)
-    t.equal(result, f.uri)
+    // replace the bitcoin: portion (case-insensitive) with lowercase
+    t.equal(result, f.uri.replace(/^bitcoin:/i, 'bitcoin:'))
   })
 
   tape('decodes ' + f.uri + (f.compliant === false ? ' (non-compliant)' : ''), function (t) {


### PR DESCRIPTION
The scheme component ("bitcoin:") is case-insensitive, and implementations must accept any combination of uppercase and lowercase letters. The rest of the URI is case-sensitive, including the query parameter keys.